### PR TITLE
chore: updated the Paypal link in donate.html

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -92,7 +92,7 @@
                             <img class="bottom" src="/resource/image/donate/arrow-right.svg">
                         </div>
                     </a> -->
-                    <a href="https://www.paypal.com/fundraiser/charity/2737335" target="_blank" alt="Paypal">
+                    <a href="https://www.paypal.com/donate/?hosted_button_id=UGQNNK7G8WQPG" target="_blank" alt="Paypal">
                         <div>
                             <img class="top" src="/resource/image/donate/paypal-logo.svg">
                             <img class="bottom" src="/resource/image/donate/arrow-right.svg">


### PR DESCRIPTION
The current link leads to an empty PayPal page. 
The new link supplied by Dr. Ishaq:
https://www.paypal.com/donate/?hosted_button_id=UGQNNK7G8WQPG  has been updated.
